### PR TITLE
Feat/new task page

### DIFF
--- a/DisHabitApp/ContentView.swift
+++ b/DisHabitApp/ContentView.swift
@@ -24,7 +24,7 @@ struct ContentView: View {
                         .toolbarVisibility(.hidden, for: .tabBar)
                     }
                     Tab(value: TabItem.task) {
-                        ObjectivePage()
+                        ObjectiveTaskPage()
                             .toolbarVisibility(.hidden, for: .tabBar)
                     }
                 }
@@ -37,7 +37,7 @@ struct ContentView: View {
                     }
                     .tag(TabItem.home)
                     .toolbar(.hidden, for: .tabBar)
-                    ObjectivePage()
+                    ObjectiveTaskPage()
                         .tag(TabItem.task)
                         .toolbar(.hidden, for: .tabBar)
                 }

--- a/DisHabitApp/View/Pages/HomePage.swift
+++ b/DisHabitApp/View/Pages/HomePage.swift
@@ -25,9 +25,10 @@ struct HomePage: View {
                             .font(.largeTitle)
                             .fontWeight(.bold)
                         Spacer()
-                        Image(systemName: "gearshape")
-                            .resizable()
-                            .frame(width: 30, height: 30)
+                        /// 設定項目がないためTestFlightでは必要ない
+//                        Image(systemName: "gearshape")
+//                            .resizable()
+//                            .frame(width: 30, height: 30)
                     }
                     .padding(.horizontal, 22)
                     .padding(.vertical, 10)

--- a/DisHabitApp/View/Pages/ObjectiveTaskPage.swift
+++ b/DisHabitApp/View/Pages/ObjectiveTaskPage.swift
@@ -1,0 +1,41 @@
+import SwiftUI
+import SwiftData
+
+struct ObjectiveTaskPage: View {
+    
+    @Query var objectives: [Objective]
+    @Query var tasks: [StandbyTask]
+    
+    var body: some View {
+        VStack(spacing: 10) {
+            Text("タスク一覧")
+                .font(.largeTitle)
+                .padding(.vertical, 30)
+            ScrollView {
+                VStack(alignment: .leading, spacing: 20) {
+                    ForEach(objectives) { objective in
+                        Text(objective.text)
+                            .font(.title)
+                            .padding(.leading, 30)
+                        ForEach(tasks) { task in
+                            /// checkedはselectedTasks.contains()で判定する
+                            /// toggleActionでappend/removeする
+                            if let taskobj = task.objective {
+                                if taskobj.id == objective.id {
+                                    CheckBoxList(isSelected: false, taskName: task.text, isReadonly: true, isLabelOnly: true,
+                                        toggleAction: {})
+                                }
+                            }
+                        }
+                    }
+                }
+                
+            }
+        }
+    }
+}
+
+
+#Preview {
+    ObjectiveTaskPage()
+}

--- a/DisHabitApp/View/Pages/ObjectiveTaskPage.swift
+++ b/DisHabitApp/View/Pages/ObjectiveTaskPage.swift
@@ -15,7 +15,7 @@ struct ObjectiveTaskPage: View {
                 VStack(alignment: .leading, spacing: 20) {
                     ForEach(objectives) { objective in
                         Text(objective.text)
-                            .font(.title)
+                            .font(.title2)
                             .padding(.leading, 30)
                         ForEach(tasks) { task in
                             /// checkedはselectedTasks.contains()で判定する


### PR DESCRIPTION
目標一覧->タスク一覧を開いた時に`TabBar`から`HomePage`に遷移しようとすると、画面上に"⚠️"とだけ表示される問題を回避するために、一旦目標とタスクを1つのページにする。